### PR TITLE
getting-started/requirements

### DIFF
--- a/getting-started/requirements.md
+++ b/getting-started/requirements.md
@@ -4,7 +4,7 @@
 | :--- | :--- |
 | CPU | X86\_64 CPU Quadcore with 2Ghz |
 | RAM | Minimum of 4GB |
-| GPU | Graphics Card: Support of OpenGL 3.0 or higher, min 1 GB Video-RAM |
+| GPU | Graphics Card: Support of OpenGL 3.3 or higher, min 1 GB Video-RAM |
 | HDD | Minimum of 2GB free space |
 | OS | min Windows 7 or Debian based Linux Derivate |
 


### PR DESCRIPTION
Changed OpenGL version from 3.0 to 3.3 in getting-started/requirements documentation.